### PR TITLE
Fix async void handlers

### DIFF
--- a/src/WebSearchIndexing/Pages/Components/Notification/BaseNotificationComponent.razor
+++ b/src/WebSearchIndexing/Pages/Components/Notification/BaseNotificationComponent.razor
@@ -19,7 +19,7 @@
                 <MudPaper Class="rounded-circle close-icon close-icon--banner"
                           Style="z-index: 1"
                           Elevation="0"
-                          @onclick="CloseBanner">
+                          @onclick="CloseBannerAsync">
                     <MudIcon Size="Size.Small" Icon="@Icons.Material.Filled.Close" Color="Color.Primary" />
                 </MudPaper>
             }

--- a/src/WebSearchIndexing/Pages/Components/Notification/BaseNotificationComponent.razor.cs
+++ b/src/WebSearchIndexing/Pages/Components/Notification/BaseNotificationComponent.razor.cs
@@ -16,7 +16,7 @@ public partial class BaseNotificationComponent : ComponentBase
     [Parameter]
     public EventCallback Closed { get; set; }
 
-    private async void CloseBanner()
+    private async Task CloseBannerAsync()
     {
         _isClosed = true;
         await Closed.InvokeAsync();

--- a/src/WebSearchIndexing/Pages/Dialogs/AddServiceAccountDialog.razor
+++ b/src/WebSearchIndexing/Pages/Dialogs/AddServiceAccountDialog.razor
@@ -10,7 +10,7 @@
                                T="IReadOnlyList<IBrowserFile>"
                                MaximumFileCount="1"
                                Accept=".json"
-                               OnFilesChanged="HandleUploadingFile">
+                               OnFilesChanged="HandleUploadingFileAsync">
                     <ButtonTemplate>
                         <MudButton HtmlTag="label"
                                    Variant="Variant.Filled"

--- a/src/WebSearchIndexing/Pages/Dialogs/AddServiceAccountDialog.razor.cs
+++ b/src/WebSearchIndexing/Pages/Dialogs/AddServiceAccountDialog.razor.cs
@@ -16,7 +16,7 @@ public partial class AddServiceAccountDialog : ComponentBase
     [CascadingParameter]
     private MudDialogInstance? _mudDialog { get; set; }
 
-    private async void HandleUploadingFile(InputFileChangeEventArgs e)
+    private async Task HandleUploadingFileAsync(InputFileChangeEventArgs e)
     {
         _isUploadedFile = false;
         StateHasChanged();

--- a/src/WebSearchIndexing/Pages/HomePage.razor.cs
+++ b/src/WebSearchIndexing/Pages/HomePage.razor.cs
@@ -42,14 +42,14 @@ public partial class HomePage : ComponentBase
     [Inject]
     private ISettingRepository? SettingRepository { get; set; }
 
-    protected override void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
 
-        InitializeData();
+        await InitializeDataAsync();
     }
 
-    private async void InitializeData()
+    private async Task InitializeDataAsync()
     {
         _setting = await SettingRepository!.GetSettingAsync();
 

--- a/src/WebSearchIndexing/Pages/Layout/Components/AccessComponent.razor
+++ b/src/WebSearchIndexing/Pages/Layout/Components/AccessComponent.razor
@@ -15,6 +15,6 @@
                       @bind-Value="_accessKey" />
     </DialogContent>
     <DialogActions>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SubmitAccessKey" Class="px-10">Submit</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SubmitAccessKeyAsync" Class="px-10">Submit</MudButton>
     </DialogActions>
 </MudDialog>

--- a/src/WebSearchIndexing/Pages/Layout/Components/AccessComponent.razor.cs
+++ b/src/WebSearchIndexing/Pages/Layout/Components/AccessComponent.razor.cs
@@ -35,7 +35,7 @@ public partial class AccessComponent : ComponentBase
         }
     }
 
-    private async void SubmitAccessKey()
+    private async Task SubmitAccessKeyAsync()
     {
         if (string.IsNullOrWhiteSpace(_accessKey))
         {

--- a/src/WebSearchIndexing/Pages/Layout/MainLayout.razor.cs
+++ b/src/WebSearchIndexing/Pages/Layout/MainLayout.razor.cs
@@ -22,7 +22,7 @@ public partial class MainLayout : LayoutComponentBase
             _isDarkMode = await _mudThemeProvider.GetSystemPreference();
             _isCanShowContent = true;
             StateHasChanged();
-            await _mudThemeProvider.WatchSystemPreference(OnSystemPreferenceChanged);
+            await _mudThemeProvider.WatchSystemPreference(OnSystemPreferenceChangedAsync);
         }
     }
 
@@ -32,7 +32,7 @@ public partial class MainLayout : LayoutComponentBase
         StateHasChanged();
     }
 
-    private async Task OnSystemPreferenceChanged(bool newValue)
+    private async Task OnSystemPreferenceChangedAsync(bool newValue)
     {
         _isDarkMode = newValue;
         StateHasChanged();

--- a/src/WebSearchIndexing/Pages/ServiceAccountsPage.razor
+++ b/src/WebSearchIndexing/Pages/ServiceAccountsPage.razor
@@ -5,7 +5,7 @@
 <MudText Typo="Typo.h5">Service accounts</MudText>
 <MudText Class="mb-5" Typo="Typo.body2">You can add your Google Cloud Platform service accounts here.</MudText>
 
-<MudButton Class="mb-4" Variant="Variant.Filled" Color="Color.Primary" OnClick="ShowAddingDialog">Add service account</MudButton>
+<MudButton Class="mb-4" Variant="Variant.Filled" Color="Color.Primary" OnClick="ShowAddingDialogAsync">Add service account</MudButton>
 
 @if (_isLoading)
 {
@@ -24,7 +24,7 @@ else
               EditTrigger="TableEditTrigger.EditButton"
               RowEditPreview="BackupItem"
               RowEditCancel="ResetItemToOriginalValues"
-              RowEditCommit="ItemHasBeenCommitted"
+              RowEditCommit="ItemHasBeenCommittedAsync"
               CanCancelEdit="true">
         <ColGroup>
             <col />
@@ -52,7 +52,7 @@ else
                         <MudIconButton Icon="@Icons.Material.Outlined.Delete"
                                        Color="Color.Error"
                                        Title="Delete"
-                                       OnClick="@(() => DeleteServiceAccount(context))" />
+                                       OnClick="@(() => DeleteServiceAccountAsync(context))" />
                     </MudTooltip>
                 </MudStack>
             </MudTd>
@@ -78,7 +78,7 @@ else
                         <MudIconButton Icon="@Icons.Material.Outlined.Delete"
                                        Color="Color.Error"
                                        Title="Delete"
-                                       OnClick="@(() => DeleteServiceAccount(context))" />
+                                       OnClick="@(() => DeleteServiceAccountAsync(context))" />
                     </MudTooltip>
                 </MudStack>
             </MudTd>

--- a/src/WebSearchIndexing/Pages/ServiceAccountsPage.razor
+++ b/src/WebSearchIndexing/Pages/ServiceAccountsPage.razor
@@ -24,7 +24,7 @@ else
               EditTrigger="TableEditTrigger.EditButton"
               RowEditPreview="BackupItem"
               RowEditCancel="ResetItemToOriginalValues"
-              RowEditCommit="ItemHasBeenCommittedAsync"
+              RowEditCommit="async (element) => await ItemHasBeenCommittedAsync(element)"
               CanCancelEdit="true">
         <ColGroup>
             <col />

--- a/src/WebSearchIndexing/Pages/ServiceAccountsPage.razor.cs
+++ b/src/WebSearchIndexing/Pages/ServiceAccountsPage.razor.cs
@@ -21,7 +21,7 @@ public partial class ServiceAccountsPage : ComponentBase
     [Inject]
     private IDialogService? DialogService { get; set; }
 
-    protected override async void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
 
@@ -31,7 +31,7 @@ public partial class ServiceAccountsPage : ComponentBase
         StateHasChanged();
     }
 
-    private async void ShowAddingDialog()
+    private async Task ShowAddingDialogAsync()
     {
         var dialog = await DialogService!.ShowAsync<AddServiceAccountDialog>("Add service account",
             new DialogOptions() { CloseButton = true, FullWidth = true });
@@ -70,7 +70,7 @@ public partial class ServiceAccountsPage : ComponentBase
         ((ServiceAccount)item).QuotaLimitPerDay = _serviceAccountBeforeEdit.QuotaLimitPerDay;
     }
 
-    private async void ItemHasBeenCommitted(object element)
+    private async Task ItemHasBeenCommittedAsync(object element)
     {
         var newQuotaValue = ((ServiceAccount)element).QuotaLimitPerDay;
 
@@ -91,7 +91,7 @@ public partial class ServiceAccountsPage : ComponentBase
         }
     }
 
-    private async void DeleteServiceAccount(ServiceAccount serviceAccount)
+    private async Task DeleteServiceAccountAsync(ServiceAccount serviceAccount)
     {
         var result = await DialogService!.ShowMessageBox("Delete service account",
             "Are you sure you want to delete this service account?",
@@ -108,12 +108,12 @@ public partial class ServiceAccountsPage : ComponentBase
 
             if (_serviceAccounts.Count == 0)
             {
-                UpdateLimit();
+                await UpdateLimitAsync();
             }
         }
     }
 
-    private async void UpdateLimit()
+    private async Task UpdateLimitAsync()
     {
         var setting = await SettingRepository!.GetSettingAsync();
         if (setting is null) return;

--- a/src/WebSearchIndexing/Pages/ServiceAccountsPage.razor.cs
+++ b/src/WebSearchIndexing/Pages/ServiceAccountsPage.razor.cs
@@ -74,7 +74,8 @@ public partial class ServiceAccountsPage : ComponentBase
     {
         var newQuotaValue = ((ServiceAccount)element).QuotaLimitPerDay;
 
-        if (newQuotaValue == _serviceAccountBeforeEdit.QuotaLimitPerDay) return;
+        if (newQuotaValue == _serviceAccountBeforeEdit.QuotaLimitPerDay)
+            return;
 
         var serviceAccount = await ServiceAccountRepository!.GetByIdAsync(((ServiceAccount)element).Id);
 

--- a/src/WebSearchIndexing/Pages/SettingsPage.razor
+++ b/src/WebSearchIndexing/Pages/SettingsPage.razor
@@ -28,7 +28,7 @@ else
                     DisableElevation="true"
                     Variant="Variant.Filled"
                    Color="@(_setting.IsEnabled ? Color.Error : Color.Success)"
-                    OnClick="ToggleEnabling">
+                    OnClick="ToggleEnablingAsync">
             @(_setting.IsEnabled ? "Disable" : "Enable") service
         </MudButton>
     </MudPaper>
@@ -60,7 +60,7 @@ else
                        DisableElevation="true"
                        Variant="Variant.Filled"
                        Color="Color.Primary"
-                       OnClick="SaveRequestsPerDay">
+                       OnClick="SaveRequestsPerDayAsync">
                 Save
             </MudButton>
         }

--- a/src/WebSearchIndexing/Pages/SettingsPage.razor.cs
+++ b/src/WebSearchIndexing/Pages/SettingsPage.razor.cs
@@ -28,7 +28,7 @@ public partial class SettingsPage : ComponentBase
 
     private bool RequestsPerDayChanged => _setting.RequestsPerDay != _oldValueRequestsPerDay;
 
-    protected override async void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
 
@@ -48,7 +48,7 @@ public partial class SettingsPage : ComponentBase
         StateHasChanged();
     }
 
-    private async void ToggleEnabling()
+    private async Task ToggleEnablingAsync()
     {
         if (_isSavingSettings) return;
 
@@ -85,7 +85,7 @@ public partial class SettingsPage : ComponentBase
         }
     }
 
-    private async void SaveRequestsPerDay()
+    private async Task SaveRequestsPerDayAsync()
     {
         if (_isSavingSettings ||
             RequestsPerDayChanged is false) return;

--- a/src/WebSearchIndexing/Pages/Urls/Components/ProcessedUrlsTableComponent.razor
+++ b/src/WebSearchIndexing/Pages/Urls/Components/ProcessedUrlsTableComponent.razor
@@ -84,7 +84,7 @@
                 <MudTd DataLabel="Processed at">@context.ProcessedAt.ToString("MMM dd, hh:mm:ss tt")</MudTd>
                 <MudTd>
                     <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.FlexEnd">                    
-                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="() => RemoveItem(context)" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="() => RemoveItemAsync(context)" />
                     </MudStack>
                 </MudTd>
             </RowTemplate>
@@ -101,7 +101,7 @@
                                    DisableElevation="true"
                                    Count="_totalPages"
                                    Selected="_currentPage"
-                                   SelectedChanged="ChangePage" />
+                                   SelectedChanged="ChangePageAsync" />
                 }
             </PagerContent>
         </MudTable>

--- a/src/WebSearchIndexing/Pages/Urls/Components/ProcessedUrlsTableComponent.razor.cs
+++ b/src/WebSearchIndexing/Pages/Urls/Components/ProcessedUrlsTableComponent.razor.cs
@@ -19,7 +19,7 @@ public partial class ProcessedUrlsTableComponent : Pages.Components.ComponentBas
     [Inject]
     private IUrlRequestRepository? UrlRequestRepository { get; set; }
 
-    protected override async void OnParametersSet()
+    protected override async Task OnParametersSetAsync()
     {
         await UpdateUrlsListAsync();
     }
@@ -40,13 +40,13 @@ public partial class ProcessedUrlsTableComponent : Pages.Components.ComponentBas
         StateHasChanged();
     }
 
-    private async void ChangePage(int page)
+    private async Task ChangePageAsync(int page)
     {
         _currentPage = page;
         await UpdateUrlsListAsync();
     }
 
-    private async void RemoveItem(UrlRequest item)
+    private async Task RemoveItemAsync(UrlRequest item)
     {
         if (await UrlRequestRepository!.DeleteAsync(item.Id))
         {

--- a/src/WebSearchIndexing/Pages/Urls/Components/RejectedUrlsTableComponent.razor
+++ b/src/WebSearchIndexing/Pages/Urls/Components/RejectedUrlsTableComponent.razor
@@ -104,7 +104,7 @@
                 <MudTd DataLabel="Processed at">@context.ProcessedAt.ToString("MMM dd, hh:mm:ss tt")</MudTd>
                 <MudTd>
                     <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.FlexEnd">
-                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="() => RemoveItem(context)" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="() => RemoveItemAsync(context)" />
                     </MudStack>
                 </MudTd>
             </RowTemplate>
@@ -121,7 +121,7 @@
                                    DisableElevation="true"
                                    Count="_totalPages"
                                    Selected="_currentPage"
-                                   SelectedChanged="ChangePage" />
+                                   SelectedChanged="ChangePageAsync" />
                 }
             </PagerContent>
         </MudTable>

--- a/src/WebSearchIndexing/Pages/Urls/Components/RejectedUrlsTableComponent.razor.cs
+++ b/src/WebSearchIndexing/Pages/Urls/Components/RejectedUrlsTableComponent.razor.cs
@@ -16,7 +16,7 @@ public partial class RejectedUrlsTableComponent : Pages.Components.ComponentBase
     [Inject]
     private IUrlRequestRepository? UrlRequestRepository { get; set; }
 
-    protected override async void OnParametersSet()
+    protected override async Task OnParametersSetAsync()
     {
         var requestsCount = await UrlRequestRepository!.GetRequestsCountAsync(UrlRequestStatus.Failed);
         _totalPages = (int)Math.Ceiling(requestsCount / (double)ROWS_PER_PAGE);
@@ -39,13 +39,13 @@ public partial class RejectedUrlsTableComponent : Pages.Components.ComponentBase
         StateHasChanged();
     }
 
-    private async void ChangePage(int page)
+    private async Task ChangePageAsync(int page)
     {
         _currentPage = page;
         await UpdateUrlsListAsync();
     }
 
-    private async void RemoveItem(UrlRequest item)
+    private async Task RemoveItemAsync(UrlRequest item)
     {
         if (await UrlRequestRepository!.DeleteAsync(item.Id))
         {

--- a/src/WebSearchIndexing/Pages/Urls/Components/UrlsTableComponent.razor
+++ b/src/WebSearchIndexing/Pages/Urls/Components/UrlsTableComponent.razor
@@ -5,7 +5,7 @@
         <MudButton Style="text-transform: none"
                    Color="Color.Success"
                    StartIcon="@Icons.Material.Filled.Add"
-                   OnClick="ShowLoadLinksDialog">
+                   OnClick="ShowLoadLinksDialogAsync">
             Add links
         </MudButton>
 
@@ -21,7 +21,7 @@
                    Color="Color.Error"
                    StartIcon="@Icons.Material.Filled.Delete"
                    IconColor="@(SelectedUrls.Any() is false ? Color.Surface : Color.Error)"
-                   OnClick="DeleteSelectedLinks">
+                   OnClick="DeleteSelectedLinksAsync">
             Delete
         </MudButton>
 
@@ -30,7 +30,7 @@
                    Color="Color.Info"
                    StartIcon="@(_isHideCompleted ? Icons.Material.Filled.RemoveRedEye : Icons.Material.Outlined.RemoveRedEye)"
                    IconColor="Color.Info"
-                   OnClick="ShowOrHideCompletedLinks">
+                   OnClick="ShowOrHideCompletedLinksAsync">
             @(_isHideCompleted ? "Show" : "Hide") completed
         </MudButton>
     </div>
@@ -180,7 +180,7 @@
                                                Icon="@Icons.Material.Filled.Save"
                                                Variant="Variant.Filled"
                                                Color="Color.Success"
-                                               OnClick="() => ItemHasBeenCommitted(context)" />
+                                               OnClick="() => ItemHasBeenCommittedAsync(context)" />
 
                                 <MudIconButton Icon="@Icons.Material.Filled.Cancel"
                                                Color="Color.Surface"
@@ -190,7 +190,7 @@
                             {
                                 <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Primary" OnClick="() => BackupItem(context)" />
                             }
-                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="() => RemoveItem(context)" />
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="() => RemoveItemAsync(context)" />
                         </MudStack>
                     </MudTd>
                 </RowTemplate>
@@ -207,7 +207,7 @@
                                        DisableElevation="true"
                                        Count="_totalPages"
                                        Selected="_currentPage"
-                                       SelectedChanged="ChangePage" />
+                                       SelectedChanged="ChangePageAsync" />
                     }
                 </PagerContent>
             </MudTable>

--- a/src/WebSearchIndexing/Pages/Urls/Components/UrlsTableComponent.razor.cs
+++ b/src/WebSearchIndexing/Pages/Urls/Components/UrlsTableComponent.razor.cs
@@ -32,7 +32,7 @@ public partial class UrlsTableComponent : Pages.Components.ComponentBase
 
     private List<UrlRequestChecked> SelectedUrls => _filteredUrls.Where(item => item.Checked).ToList();
 
-    protected override async void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
 
@@ -57,13 +57,13 @@ public partial class UrlsTableComponent : Pages.Components.ComponentBase
         StateHasChanged();
     }
 
-    private async void ChangePage(int page)
+    private async Task ChangePageAsync(int page)
     {
         _currentPage = page;
         await UpdateUrlsListAsync();
     }
 
-    private async void ShowLoadLinksDialog()
+    private async Task ShowLoadLinksDialogAsync()
     {
         var parameters = new DialogParameters()
         {
@@ -83,7 +83,7 @@ public partial class UrlsTableComponent : Pages.Components.ComponentBase
         _filteredUrls.ForEach(item => item.Checked = _isClickedCheckedAll);
     }
 
-    private async void DeleteSelectedLinks()
+    private async Task DeleteSelectedLinksAsync()
     {
         var dialogResponse = await DialogService!.ShowMessageBox("Delete urls",
                                                                  $"You really want to delete the selected urls? ({SelectedUrls.Count()} pc.)",
@@ -98,7 +98,7 @@ public partial class UrlsTableComponent : Pages.Components.ComponentBase
         }
     }
 
-    private async void ShowOrHideCompletedLinks()
+    private async Task ShowOrHideCompletedLinksAsync()
     {
         _isHideCompleted = !_isHideCompleted;
         await UpdateUrlsListAsync();
@@ -141,7 +141,7 @@ public partial class UrlsTableComponent : Pages.Components.ComponentBase
         item.UrlRequest.Priority = _backupItem.UrlRequest.Priority;
     }
 
-    private async void ItemHasBeenCommitted(UrlRequestChecked item)
+    private async Task ItemHasBeenCommittedAsync(UrlRequestChecked item)
     {
         if (IsUrlValid(item.UrlRequest.Url) is false)
         {
@@ -164,7 +164,7 @@ public partial class UrlsTableComponent : Pages.Components.ComponentBase
         }
     }
 
-    private async void RemoveItem(UrlRequestChecked item)
+    private async Task RemoveItemAsync(UrlRequestChecked item)
     {
         if (item.Edited)
         {

--- a/src/WebSearchIndexing/Pages/Urls/Dialogs/LoadUrlsDialog.razor
+++ b/src/WebSearchIndexing/Pages/Urls/Dialogs/LoadUrlsDialog.razor
@@ -41,7 +41,7 @@
                 <ChildContent>
                     <MudFileUpload T="IReadOnlyList<IBrowserFile>"
                                    MaximumFileCount="1"
-                                   OnFilesChanged="HandleFileSelection"
+                                   OnFilesChanged="HandleFileSelectionAsync"
                                    Hidden="false"
                                    InputClass="absolute overflow-hidden mud-width-full mud-height-full z-20"
                                    InputStyle="opacity:0"
@@ -81,6 +81,6 @@
     </DialogContent>
     <DialogActions>
         <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="Close">Cancel</MudButton>
-        <MudButton Variant="Variant.Filled" Color="Color.Success" Disabled="_isSavingUrls" OnClick="Save">Save</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Success" Disabled="_isSavingUrls" OnClick="SaveAsync">Save</MudButton>
     </DialogActions>
 </MudDialog>

--- a/src/WebSearchIndexing/Pages/Urls/Dialogs/LoadUrlsDialog.razor.cs
+++ b/src/WebSearchIndexing/Pages/Urls/Dialogs/LoadUrlsDialog.razor.cs
@@ -35,7 +35,7 @@ public partial class LoadUrlsDialog : ComponentBase
         _urlRequests = [];
     }
 
-    private async void Save()
+    private async Task SaveAsync()
     {
         if (_isSavingUrls) return;
 
@@ -85,7 +85,7 @@ public partial class LoadUrlsDialog : ComponentBase
             .ToList();
     }
 
-    protected async Task HandleFileSelection(InputFileChangeEventArgs e)
+    protected async Task HandleFileSelectionAsync(InputFileChangeEventArgs e)
     {
         ClearDragClass();
 


### PR DESCRIPTION
## Summary
- replace `async void` lifecycle methods with `Task`-returning versions and add `Async` suffix
- update event handler names across components and markup accordingly

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496c1e81088326a04e6b497083f5a0